### PR TITLE
Add deploy_left script for easier launch

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,3 +10,5 @@ This is an advanced intraday trading assistant powered by Codex & GPT. It analyz
 - Google Sheets integration (optional)
 
 Made with ❤️ to protect retail traders from market dhoka.
+## Deployment
+Run `./deploy_left.sh` to start the server locally using Gunicorn.

--- a/deploy_left.sh
+++ b/deploy_left.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+# Simple deployment script to launch the Flask app with Gunicorn
+# Usage: ./deploy_left.sh
+
+gunicorn --bind 0.0.0.0:10000 app:app


### PR DESCRIPTION
## Summary
- add a small `deploy_left.sh` script that runs the Flask app with Gunicorn
- document the script usage in the README

## Testing
- `python -m py_compile app.py codex_main.py tradingview_script.py utils.py`
- `flake8` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6880135038b88324beca52a036f7c6e2